### PR TITLE
update logic to return status code 1 on error or invalid manifests

### DIFF
--- a/pkg/manifest/processor.go
+++ b/pkg/manifest/processor.go
@@ -39,14 +39,12 @@ func (p *Processor) ProcessManifests(files []string, process StringToErrorFunc) 
 }
 
 func (p *Processor) ProcessValidationManifests(files []string, process StringToValidateResultFunc) error {
-	failed := false
 	var validCount, invalidCount, errorCount, skippedCount int
 
 	for _, file := range files {
 		summary, validationErr := process(file)
 		if validationErr != nil {
 			p.log.Error("validation failed", "file", file, "error", validationErr.Error())
-			failed = true
 		}
 
 		validCount += summary.ValidCount
@@ -59,7 +57,7 @@ func (p *Processor) ProcessValidationManifests(files []string, process StringToV
 
 	p.log.Info("validation completed", "totalResources", totalResources, "valid", validCount, "invalid", invalidCount, "errors", errorCount, "skipped", skippedCount)
 
-	if failed {
+	if errorCount > 0 || invalidCount > 0 {
 		return errors.New("validation failed")
 	}
 


### PR DESCRIPTION
This pull request updates the validation logic in the `ProcessValidationManifests` method of the `Processor` class to more accurately determine when validation should be considered failed. The main change is shifting from a generic failure flag to directly checking the counts of errors and invalid results.

Validation logic improvements:

* [`pkg/manifest/processor.go`](diffhunk://#diff-3565a9299512ee5560b46d66a370ed3ac3735a22df4cbec3ad7c87aa2c7b2066L42-L49): Removed the unused `failed` flag and updated the failure condition to return an error if there are any validation errors or invalid results, making the logic clearer and more robust. [[1]](diffhunk://#diff-3565a9299512ee5560b46d66a370ed3ac3735a22df4cbec3ad7c87aa2c7b2066L42-L49) [[2]](diffhunk://#diff-3565a9299512ee5560b46d66a370ed3ac3735a22df4cbec3ad7c87aa2c7b2066L62-R60)

![Programmer Coding GIF](https://media4.giphy.com/media/zOvBKUUEERdNm/giphy.gif)