### PR TITLE
add test for format, render and validate

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/prometheus-community/pro-bing v0.7.0
 	github.com/prometheus/client_golang v1.23.0
 	github.com/spf13/cobra v1.10.1
+	github.com/stretchr/testify v1.11.0
 	github.com/yannh/kubeconform v0.7.0
 	go.yaml.in/yaml/v4 v4.0.0-rc.2
 	golang.org/x/oauth2 v0.30.0

--- a/pkg/manifest/formatter_test.go
+++ b/pkg/manifest/formatter_test.go
@@ -1,0 +1,71 @@
+package manifest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatManifestValidJsonnet(t *testing.T) {
+	validJsonnet := `
+{
+host: "localhost",
+port: 8080,
+ingress: [],
+}
+`
+
+	tmp := t.TempDir()
+	filename := writeContentToTmpDir(tmp, validJsonnet, "valid.jsonnet")
+
+	res := FormatManifest(filename)
+	assert.NoError(t, res, "expected no error for valid Jsonnet input")
+}
+
+func TestFormatManifestInvalidJsonnet(t *testing.T) {
+	invalidJsonnet := `
+{
+host: localhost
+port: 8080,
+ingress = []
+}
+`
+
+	tmp := t.TempDir()
+	filename := writeContentToTmpDir(tmp, invalidJsonnet, "invalid.jsonnet")
+
+	res := FormatManifest(filename)
+	assert.Error(t, res, "expected error for invalid Jsonnet input")
+}
+
+func TestFormatManifestValidYaml(t *testing.T) {
+	validYaml := `
+application:
+  host: localhost
+  port: 8080
+  ingress:
+    - item
+`
+
+	tmp := t.TempDir()
+	filename := writeContentToTmpDir(tmp, validYaml, "valid.yaml")
+
+	res := FormatManifest(filename)
+	assert.NoError(t, res, "expected no error for valid Yaml input")
+}
+
+func TestFormatManifestInvalidYaml(t *testing.T) {
+	invalidYaml := `
+application:
+		host: localhost
+port: 8080
+	ingress
+}
+`
+
+	tmp := t.TempDir()
+	filename := writeContentToTmpDir(tmp, invalidYaml, "invalid.yaml")
+
+	res := FormatManifest(filename)
+	assert.Error(t, res, "expected error for invalid Yaml input")
+}

--- a/pkg/manifest/renderer_test.go
+++ b/pkg/manifest/renderer_test.go
@@ -1,0 +1,80 @@
+package manifest
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func writeContentToTmpDir(dir string, content string, filename string) string {
+	path := dir + string(os.PathSeparator) + filename
+
+	os.WriteFile(path, []byte(content), 0644)
+
+	return path
+}
+
+func TestRenderManifestValidJsonnet(t *testing.T) {
+	validJsonnet := `
+{
+host: "localhost",
+port: 8080,
+ingress: [],
+}
+`
+
+	tmp := t.TempDir()
+	filename := writeContentToTmpDir(tmp, validJsonnet, "valid.jsonnet")
+
+	res := NewRenderer().RenderManifest(filename)
+	assert.NoError(t, res, "expected no error for valid Jsonnet input")
+}
+
+func TestRenderManifestInvalidJsonnet(t *testing.T) {
+	invalidJsonnet := `
+{
+host: localhost
+port: 8080,
+ingress = []
+}
+`
+
+	tmp := t.TempDir()
+	filename := writeContentToTmpDir(tmp, invalidJsonnet, "invalid.jsonnet")
+
+	res := NewRenderer().RenderManifest(filename)
+	assert.Error(t, res, "expected error for invalid Jsonnet input")
+}
+
+func TestRenderManifestValidYaml(t *testing.T) {
+	validYaml := `
+application:
+  host: localhost
+  port: 8080
+  ingress:
+    - item
+`
+
+	tmp := t.TempDir()
+	filename := writeContentToTmpDir(tmp, validYaml, "valid.yaml")
+
+	res := NewRenderer().RenderManifest(filename)
+	assert.NoError(t, res, "expected no error for valid Yaml input")
+}
+
+func TestRenderManifestInvalidYaml(t *testing.T) {
+	invalidYaml := `
+application:
+		host: localhost
+port: 8080
+	ingress
+}
+`
+
+	tmp := t.TempDir()
+	filename := writeContentToTmpDir(tmp, invalidYaml, "invalid.yaml")
+
+	res := NewRenderer().RenderManifest(filename)
+	assert.Error(t, res, "expected error for invalid Yaml input")
+}

--- a/pkg/manifest/validator_test.go
+++ b/pkg/manifest/validator_test.go
@@ -1,0 +1,153 @@
+package manifest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateManifestValidJsonnetManifest(t *testing.T) {
+	validJsonnetManifest := `
+{
+  apiVersion: "skiperator.kartverket.no/v1alpha1",
+  kind: "Application",
+  metadata: {
+    name: "valid-manifest",
+    namespace: "devex",
+  },
+  spec: {
+    image: "kartverket/example",
+    port: 8080,
+    replicas: {
+      min: 1,
+      max: 5,
+    },
+  },
+}
+`
+
+	tmp := t.TempDir()
+	filename := writeContentToTmpDir(tmp, validJsonnetManifest, "valid.jsonnet")
+
+	result, err := NewValidator(tmp).ValidateManifest(filename)
+
+	assert.NoError(t, err, "ValidateManifest should not return an error for valid Jsonnet input")
+	assert.Equal(t, 0, result.ErrorCount)
+	assert.Equal(t, 0, result.InvalidCount)
+	assert.Equal(t, 0, result.SkippedCount)
+	assert.Equal(t, 1, result.ValidCount)
+}
+
+func TestValidateManifestValidJsonnet(t *testing.T) {
+	validJsonnet := `
+{
+host: "localhost",
+port: 8080,
+ingress: [],
+}
+`
+
+	tmp := t.TempDir()
+	filename := writeContentToTmpDir(tmp, validJsonnet, "valid.jsonnet")
+
+	result, err := NewValidator(tmp).ValidateManifest(filename)
+
+	assert.NoError(t, err, "ValidateManifest should not return an error for valid Jsonnet input")
+	assert.Equal(t, 0, result.ErrorCount)
+	assert.Equal(t, 1, result.InvalidCount)
+	assert.Equal(t, 0, result.SkippedCount)
+	assert.Equal(t, 0, result.ValidCount)
+}
+
+func TestValidateManifestInvalidJsonnet(t *testing.T) {
+	invalidJsonnet := `
+{
+host: localhost
+port: 8080,
+ingress = []
+}
+`
+
+	tmp := t.TempDir()
+	filename := writeContentToTmpDir(tmp, invalidJsonnet, "invalid.jsonnet")
+
+	result, err := NewValidator(tmp).ValidateManifest(filename)
+
+	assert.Error(t, err, "expected error for invalid Jsonnet input")
+
+	assert.Equal(t, 1, result.ErrorCount)
+	assert.Equal(t, 0, result.InvalidCount)
+	assert.Equal(t, 0, result.SkippedCount)
+	assert.Equal(t, 0, result.ValidCount)
+}
+
+func TestValidateManifestValidYamlManifest(t *testing.T) {
+	validYamlManifest := `
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: valid-manifest
+  namespace: devex
+spec:
+  image: "kartverket/example"
+  port: 8080
+  replicas:
+    min: 1
+    max: 5
+`
+
+	tmp := t.TempDir()
+	filename := writeContentToTmpDir(tmp, validYamlManifest, "valid.yaml")
+
+	result, err := NewValidator(tmp).ValidateManifest(filename)
+
+	assert.NoError(t, err, "ValidateManifest should not return an error for valid yaml input")
+	assert.Equal(t, 0, result.ErrorCount)
+	assert.Equal(t, 0, result.InvalidCount)
+	assert.Equal(t, 0, result.SkippedCount)
+	assert.Equal(t, 1, result.ValidCount)
+}
+
+func TestValidateManifestValidYaml(t *testing.T) {
+	validYaml := `
+application:
+  host: localhost
+  port: 8080
+  ingress:
+    - item
+`
+
+	tmp := t.TempDir()
+	filename := writeContentToTmpDir(tmp, validYaml, "valid.yaml")
+
+	result, err := NewValidator(tmp).ValidateManifest(filename)
+
+	assert.NoError(t, err, "expected no error for valid Yaml input")
+
+	assert.Equal(t, 0, result.ErrorCount)
+	assert.Equal(t, 1, result.InvalidCount)
+	assert.Equal(t, 0, result.SkippedCount)
+	assert.Equal(t, 0, result.ValidCount)
+}
+
+func TestValidateManifestInvalidYaml(t *testing.T) {
+	invalidYaml := `
+application:
+		host: localhost
+port: 8080
+	ingress
+}
+`
+
+	tmp := t.TempDir()
+	filename := writeContentToTmpDir(tmp, invalidYaml, "invalid.yaml")
+
+	result, err := NewValidator(tmp).ValidateManifest(filename)
+
+	assert.Error(t, err, "expected error for invalid Yaml input")
+
+	assert.Equal(t, 1, result.ErrorCount)
+	assert.Equal(t, 0, result.InvalidCount)
+	assert.Equal(t, 0, result.SkippedCount)
+	assert.Equal(t, 0, result.ValidCount)
+}


### PR DESCRIPTION
# Enhetstester for manifest pakken

### Render og format 
Enkle tester som sjekker om de ulike operasjonene feiler eller ikke som 
forventet med gyldig og ugyldig input i jsonnet og yaml format.

### Validate
Testene for validate sjekker at `ValidateResult` structen har forventet innhold.

## Kjør testene
```shell
# kjør alle testene i pakken
cd pkg/manifest
go test

# kjør kun enkelt test
go test -run [testnavn/funksjonsnavn]

# kjør bolker av tester
go test -run ^TestValidate # kjør alle validate tester
go test -run ^TestRender # kjør alle render tester
go test -run ^TestFormat # kjør alle format tester
```