### PR TITLE
fix detect filetype and jsonnet render using ast

### DIFF
--- a/pkg/manifest/renderer.go
+++ b/pkg/manifest/renderer.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"fmt"
 	"log/slog"
 
 	"github.com/google/go-jsonnet"
@@ -33,11 +34,16 @@ func (r *Renderer) RenderManifest(file *Document) error {
 }
 
 func (r *Renderer) renderJsonnet(file *Document) error {
-	result, err := r.jsonnet.EvaluateAnonymousSnippet(file.Name, file.Content)
-
+	node, err := jsonnet.SnippetToAST(file.Name, file.Content)
 	if err != nil {
-		return err
+		return fmt.Errorf("parse jsonnet %q: %w", file.Name, err)
 	}
+
+	result, err := r.jsonnet.Evaluate(node)
+	if err != nil {
+		return fmt.Errorf("evaluate jsonnet %q: %w", file.Name, err)
+	}
+
 	r.rawOutput.Info(result)
 
 	return nil

--- a/pkg/utils/fileUtils.go
+++ b/pkg/utils/fileUtils.go
@@ -126,6 +126,20 @@ func DetectFiletype(content []byte) (string, error) {
 	if len(trimmed) == 0 {
 		return "", errors.New("unable to detect filetype: Empty file content")
 	}
+
+	jsonnetPrefixes := [][]byte{
+		[]byte("local "),
+		[]byte("import "),
+		[]byte("importstr "),
+		[]byte("importbin "),
+		[]byte("function"),
+	}
+	for _, p := range jsonnetPrefixes {
+		if bytes.HasPrefix(trimmed, p) {
+			return constants.ManifestSuffixJsonnet, nil
+		}
+	}
+
 	firstChar := trimmed[0]
 
 	switch firstChar {

--- a/testdata/jsonnet/advanced/func.libsonnet
+++ b/testdata/jsonnet/advanced/func.libsonnet
@@ -1,0 +1,43 @@
+function(
+  env,
+  version,
+  name='backend',
+  clientId,
+) [
+  {
+    apiVersion: 'skiperator.kartverket.no/v1alpha1',
+    kind: 'Application',
+    metadata: {
+      name: name,
+    },
+    spec: {
+      image: version,
+      port: 8080,
+      liveness: {
+        path: '/health',
+        port: 8080,
+      },
+      readiness: {
+        path: '/health',
+        port: 8080,
+      },
+      resources: {
+        requests: {
+          cpu: '25m',
+          memory: '256Mi',
+        },
+      },
+      env: [
+        {
+          name: 'clientId',
+          value: clientId,
+        },
+
+        {
+          name: 'skipEnv',
+          value: env,
+        },
+      ],
+    },
+  },
+]

--- a/testdata/jsonnet/advanced/manifest.jsonnet
+++ b/testdata/jsonnet/advanced/manifest.jsonnet
@@ -1,0 +1,8 @@
+local application = import './func.libsonnet';
+
+
+application(
+  env='dev',
+  version='v1.2.1',
+  clientId='abcd'
+)


### PR DESCRIPTION
# 🐛 Fiks render bug med stdin


**Problem**
`DetectFiletype` klarte ikke å gjenkjenne jsonnet filer som ikke startet med [ eller {

**Endringer**
- Oppdater `DetectFiletype` til å se etter nøkkelord som import, local etc.
- Endret renderjsonnet til å bruke  `jsonnet.SnippetToAST`
- Laget anonymiserte testfiler basert på ekte app-repo konfigurasjonsfiler


**Nåværende oppførsel**

Dersom du piper en jsonnet fil inn til skipctl render og denne har en import, så må du 
være i samme mappe som jsonnet filen for at jsonnet-evaluatoren skal finne 
andre libsonnet filer fra relative import paths.

Den samme oppførselen har du også viss du prøver å gjøre det samme med den 
vanlige `jsonnet` kommandoen i terminalen.
