### PR TITLE
:construction: WIP on diff

### DIFF
--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kartverket/skipctl/pkg/constants"
+	"github.com/kartverket/skipctl/pkg/manifest"
+	"github.com/kartverket/skipctl/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+var diffCmd = &cobra.Command{
+	Use:   "diff",
+	Short: "Diff manifest",
+	Long: fmt.Sprintf(`Recursively diff manifest files in the specified path.
+
+Supported formats are: %s.
+
+Any errors will be printed to stderr. Returns 0 if all input files are diffed
+correctly, otherwise return code 1 is used to indicate failure.`,
+		strings.Join(constants.ManifestSuffixes, ", ")),
+	RunE:          runDiff,
+	SilenceErrors: true,
+	SilenceUsage:  true,
+}
+
+func runDiff(_ *cobra.Command, _ []string) error {
+	filenames, err := utils.FindFilesWithSuffixes(path, constants.ManifestSuffixes)
+	if err != nil {
+		log.Error("Error collecting files", "error", err.Error())
+		return err
+	}
+	manifestFiles, merr := manifest.FromFiles(filenames)
+	if merr != nil {
+		log.Error("Error collecting manifest files from filenames", "error", merr.Error())
+		return merr
+	}
+	if len(manifestFiles) == 0 {
+		log.Info("No manifests found.")
+		return nil
+	}
+	processor := manifest.NewDocumentProcessor()
+	err = processor.ProcessDocuments(manifestFiles, manifest.DiffDocuments)
+	if err != nil {
+		log.Error("processing error", "error", err)
+	}
+	return err
+}
+func init()

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -10,6 +10,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	commitHash string
+)
+
 var diffCmd = &cobra.Command{
 	Use:   "diff",
 	Short: "Diff manifest",
@@ -41,10 +45,16 @@ func runDiff(_ *cobra.Command, _ []string) error {
 		return nil
 	}
 	processor := manifest.NewDocumentProcessor()
-	err = processor.ProcessDocuments(manifestFiles, manifest.DiffDocuments)
+
+	differ := manifest.NewDiffer(commitHash)
+
+	err = processor.ProcessDocuments(manifestFiles, differ.DiffManifest)
 	if err != nil {
 		log.Error("processing error", "error", err)
 	}
 	return err
 }
-func init()
+func init() {
+	diffCmd.Flags().StringVar(&commitHash, "hash", "HEAD", "Commit hash to diff against (default HEAD)")
+	manifestCmd.AddCommand(diffCmd)
+}

--- a/pkg/manifest/differ.go
+++ b/pkg/manifest/differ.go
@@ -1,0 +1,30 @@
+package manifest
+
+import (
+	"log/slog"
+
+	"github.com/kartverket/skipctl/pkg/logging"
+)
+
+type Differ struct {
+	renderer  *Renderer
+	rawOutput *slog.Logger
+	prevHash  string
+}
+
+func NewDiffer(prevHash string) *Differ {
+	return &Differ{
+		renderer:  NewRenderer(),
+		rawOutput: logging.RawLogger(),
+		prevHash:  prevHash,
+	}
+}
+func (d *Differ) DiffManifest(file *Document) error {
+	prevDoc, err := file.FromPrevHash(d.prevHash)
+	if err != nil {
+		return err
+	}
+	d.rawOutput.Info(file.Content)
+	d.rawOutput.Info(prevDoc.Content)
+	return nil
+}

--- a/pkg/manifest/differ.go
+++ b/pkg/manifest/differ.go
@@ -1,30 +1,63 @@
 package manifest
 
 import (
+	"bytes"
 	"log/slog"
 
 	"github.com/kartverket/skipctl/pkg/logging"
+	"github.com/kartverket/skipctl/pkg/utils"
 )
 
 type Differ struct {
-	renderer  *Renderer
-	rawOutput *slog.Logger
-	prevHash  string
+	renderer     *Renderer
+	rawOutput    *slog.Logger
+	prevHash     string
+	renderBuffer *bytes.Buffer
+	logger       *slog.Logger
 }
 
 func NewDiffer(prevHash string) *Differ {
+	buf := &bytes.Buffer{}
 	return &Differ{
-		renderer:  NewRenderer(),
-		rawOutput: logging.RawLogger(),
-		prevHash:  prevHash,
+		renderer:     NewRenderer(logging.NewRawLoggerTo(buf)),
+		rawOutput:    logging.RawLogger(),
+		logger:       logging.Logger(),
+		prevHash:     prevHash,
+		renderBuffer: buf,
 	}
 }
 func (d *Differ) DiffManifest(file *Document) error {
-	prevDoc, err := file.FromPrevHash(d.prevHash)
+	prevFile, err := file.FromPrevHash(d.prevHash)
 	if err != nil {
 		return err
 	}
-	d.rawOutput.Info(file.Content)
-	d.rawOutput.Info(prevDoc.Content)
+
+	// render current manifest to buffer
+	d.renderBuffer.Reset()
+	err = d.renderer.RenderManifest(file)
+	if err != nil {
+		return err
+	}
+	rendered := d.renderBuffer.String()
+
+	// render previous manifest to buffer
+	d.renderBuffer.Reset()
+	err = d.renderer.RenderManifest(prevFile)
+	if err != nil {
+		return err
+	}
+	prevRendered := d.renderBuffer.String()
+
+	// diff the manifest outputs
+	diff, err := utils.Diff(prevRendered, rendered)
+	if err != nil {
+		return err
+	}
+
+	if diff != "" {
+		d.logger.Info("diff", "file", file.Name, "commit_hash", d.prevHash)
+		d.rawOutput.Info(diff + "\n")
+	}
+
 	return nil
 }

--- a/pkg/manifest/document.go
+++ b/pkg/manifest/document.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -18,6 +19,24 @@ type Document struct {
 	Permissions os.FileMode
 	Content     string
 	FromStdin   bool
+}
+
+func (d *Document) FromPrevHash(hash string) (*Document, error) {
+	cmd := exec.Command("git", "show", fmt.Sprintf("HEAD:%s", d.Name))
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+	return &Document{
+		Name:        d.Name,
+		Extension:   d.Extension,
+		Permissions: d.Permissions,
+		Content:     out.String(),
+		FromStdin:   false,
+	}, nil
 }
 
 func (r *Document) Write(content string) error {

--- a/pkg/manifest/document.go
+++ b/pkg/manifest/document.go
@@ -22,13 +22,13 @@ type Document struct {
 }
 
 func (d *Document) FromPrevHash(hash string) (*Document, error) {
-	cmd := exec.Command("git", "show", fmt.Sprintf("HEAD:%s", d.Name))
+	cmd := exec.Command("git", "show", fmt.Sprintf("%s:%s", hash, d.Name))
 	var out bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to read file from hash: file=%s commit_hash=%s", d.Name, hash)
 	}
 	return &Document{
 		Name:        d.Name,

--- a/pkg/utils/files.go
+++ b/pkg/utils/files.go
@@ -2,12 +2,14 @@
 package utils
 
 import (
+	"bufio"
 	"bytes"
 	"errors"
 	"fmt"
 	"io"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -120,4 +122,72 @@ func DetectFiletype(content []byte) (string, error) {
 	default:
 		return constants.ManifestSuffixYaml, nil
 	}
+}
+func Diff(previous, current string) (string, error) {
+	dir, err := os.MkdirTemp("", "godiff-*")
+	if err != nil {
+		return "", fmt.Errorf("create temp dir: %w", err)
+	}
+	defer os.RemoveAll(dir)
+
+	aPath := filepath.Join(dir, "a.txt")
+	bPath := filepath.Join(dir, "b.txt")
+
+	if err := os.WriteFile(aPath, []byte(previous), 0o600); err != nil {
+		return "", fmt.Errorf("write previous: %w", err)
+	}
+	if err := os.WriteFile(bPath, []byte(current), 0o600); err != nil {
+		return "", fmt.Errorf("write current: %w", err)
+	}
+
+	// -U0 => zero context lines
+	// -L labels => avoids temp paths in headers
+	cmd := exec.Command("diff", "-U0", "-L", "previous", "-L", "current", aPath, bPath)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	runErr := cmd.Run()
+
+	if runErr == nil {
+		return "", nil // no diff
+	}
+	var exitErr *exec.ExitError
+	if errors.As(runErr, &exitErr) {
+		if exitErr.ExitCode() == 1 {
+			// Differences found: post-process like `sed '1,/^@@/d'`
+			out := stripUntilFirstHunk(stdout.String())
+			return out, nil
+		}
+		return "", fmt.Errorf("diff failed (exit %d): %s", exitErr.ExitCode(), strings.TrimSpace(stderr.String()))
+	}
+	if errors.Is(runErr, exec.ErrNotFound) {
+		return "", fmt.Errorf("system 'diff' not found in PATH")
+	}
+	return "", fmt.Errorf("running diff: %w", runErr)
+}
+
+// stripUntilFirstHunk removes everything before and including the first line
+// that starts with "@@", similar to: sed '1,/^@@/d'
+func stripUntilFirstHunk(s string) string {
+	scanner := bufio.NewScanner(strings.NewReader(s))
+	var b strings.Builder
+	seenHunk := false
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !seenHunk {
+			if strings.HasPrefix(line, "@@") {
+				seenHunk = true
+				continue
+			}
+			continue
+		}
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	if err := scanner.Err(); err != nil {
+		return s
+	}
+	return strings.TrimRight(b.String(), "\n")
 }

--- a/testdata/jsonnet/diff.jsonnet
+++ b/testdata/jsonnet/diff.jsonnet
@@ -1,4 +1,0 @@
-{
-  test: 'hello',
-  number: 12 + 4,
-}

--- a/testdata/jsonnet/diff.jsonnet
+++ b/testdata/jsonnet/diff.jsonnet
@@ -1,0 +1,4 @@
+{
+  test: 'hello',
+  number: 12 + 4,
+}

--- a/testdata/jsonnet/diff/another_diff.jsonnet
+++ b/testdata/jsonnet/diff/another_diff.jsonnet
@@ -7,4 +7,10 @@
       'cycling',
     ] + ['reading'],
   },
+} + {
+  person+: {
+    hobbies+: [
+      'swimming',
+    ],
+  },
 }

--- a/testdata/jsonnet/diff/another_diff.jsonnet
+++ b/testdata/jsonnet/diff/another_diff.jsonnet
@@ -1,0 +1,10 @@
+{
+  person: {
+    name: 'Alice',
+    age: 30 + 12 + 'bob',
+    hobbies: [
+      'reading',
+      'cycling',
+    ] + ['reading'],
+  },
+}

--- a/testdata/jsonnet/diff/diff.jsonnet
+++ b/testdata/jsonnet/diff/diff.jsonnet
@@ -1,4 +1,4 @@
 {
   test: 'hello',
-  number: 12 + 6,
+  number: 15 + 6,
 }

--- a/testdata/jsonnet/diff/diff.jsonnet
+++ b/testdata/jsonnet/diff/diff.jsonnet
@@ -1,0 +1,4 @@
+{
+  test: 'hello',
+  number: 12 + 6,
+}


### PR DESCRIPTION
# Diff av manifester

Diff kommandoen lar deg se hvordan json output endrer seg basert på endringer du har gjort.
Kommandoen tar inn en commit hash som flagg (default er HEAD) som bestemmer hvilken 
versjon av den samme filen du skal sammenligne med.


## Eksempel på bruk

```jsonnet

// slik ser filen ut ved forrige commit 

{
  person: {
    name: 'Alice',
    age: 30 + 12 + 'bob',
    hobbies: [
      'reading',
      'cycling',
    ] + ['reading'],
  },
}

// nå ser filen slik ut

{
  person: {
    name: 'Alice',
    age: 30 + 12 + 'bob',
    hobbies: [
      'reading',
      'cycling',
    ] + ['reading'],
  },
} + {
  person+: {
    hobbies+: [
      'swimming',
    ],
  },
}

```

```shell
# ved å kjøre diff kommandoen
skipctl  manifests diff --path=testdata/jsonnet/diff/another_diff.jsonnet


# får man dette som output
time=2025-09-15T17:37:27.609+02:00 level=INFO msg=diff file=testdata/jsonnet/diff/another_diff.jsonnet commit_hash=HEAD
-         "reading"
+         "reading",
+         "swimming"
```