### PR TITLE
🐛 fix output from validate to stdout from stderr

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/kartverket/skipctl/pkg/constants"
+	"github.com/kartverket/skipctl/pkg/logging"
 	"github.com/kartverket/skipctl/pkg/manifest"
 	"github.com/kartverket/skipctl/pkg/utils"
 	"github.com/spf13/cobra"
@@ -66,8 +67,13 @@ func runValidate(_ *cobra.Command, args []string) error {
 
 	result := validator.GetResults()
 	totalResources := result.GetTotalResources()
-	log.Info(fmt.Sprintf("validation completed: totalResources=%d, valid=%d, invalid=%d, errors=%d, skipped=%d",
-		totalResources, result.ValidCount, result.InvalidCount, result.ErrorCount, result.SkippedCount))
+	log.InfoContext(logging.DefaultStdoutContext, "validation completed",
+		"totalResources", totalResources,
+		"valid", result.ValidCount,
+		"invalid", result.InvalidCount,
+		"errors", result.ErrorCount,
+		"skipped", result.SkippedCount,
+	)
 
 	// Cobra does not call the PostRun or PersistentPostRun functions if the program exits with an error (os.Exit(>0))
 	// Reported in https://github.com/spf13/cobra/issues/1893

--- a/pkg/logging/log.go
+++ b/pkg/logging/log.go
@@ -11,27 +11,34 @@ import (
 	"github.com/pkg/errors"
 )
 
-var logger *slog.Logger
-var rawLogger *slog.Logger
-var leveler *slog.LevelVar
+var (
+	logger    *slog.Logger
+	rawLogger *slog.Logger
+	leveler   *slog.LevelVar
+	lock      sync.Mutex
 
-var lock sync.Mutex
+	ctxStdoutKey stdoutCtxKey
+
+	DefaultStdoutContext = ForceStdoutContext(context.Background())
+)
+
+type stdoutCtxKey struct{}
 
 type splitHandler struct {
-	stdout slog.Handler
-	stderr slog.Handler
+	stdout, stderr slog.Handler
 }
 
 func (h *splitHandler) Enabled(ctx context.Context, level slog.Level) bool {
-	// All routing happens in Handle; Enabled just defers to one handler (options identical).
-	return h.stdout.Enabled(ctx, level)
+	// Delegate; assume same levels configured on both.
+	return h.stdout.Enabled(ctx, level) || h.stderr.Enabled(ctx, level)
 }
 
 func (h *splitHandler) Handle(ctx context.Context, r slog.Record) error {
-	if r.Level == slog.LevelInfo {
+	toStdout, _ := ctx.Value(ctxStdoutKey).(bool)
+
+	if toStdout {
 		return h.stdout.Handle(ctx, r)
 	}
-	// Warn, Error (and optionally Debug if enabled) go to stderr.
 	return h.stderr.Handle(ctx, r)
 }
 
@@ -56,6 +63,7 @@ func init() {
 	// This is the default before anyone calls this function
 	ConfigureLogging("json", false)
 }
+
 func ConfigureLogging(mode string, isDebug bool) *slog.Logger {
 	parsedMode, err := parseOutputMode(mode)
 	if err != nil {
@@ -81,9 +89,8 @@ func ConfigureLogging(mode string, isDebug bool) *slog.Logger {
 			panic(errors.Errorf("invalid output option: %v", parsedMode))
 		}
 	}
-	stdoutBase := newHandler(os.Stdout)
-	stderrBase := newHandler(os.Stderr)
-	splitHandler := &splitHandler{stdout: stdoutBase, stderr: stderrBase}
+
+	splitHandler := &splitHandler{stdout: newHandler(os.Stdout), stderr: newHandler(os.Stderr)}
 	// slog-context outputs key-values found in the context to the log output
 	ctxHandler := slogcontext.NewHandler(splitHandler)
 
@@ -91,6 +98,10 @@ func ConfigureLogging(mode string, isDebug bool) *slog.Logger {
 	defer lock.Unlock()
 	logger = slog.New(ctxHandler)
 	return logger
+}
+
+func ForceStdoutContext(parent context.Context) context.Context {
+	return context.WithValue(parent, ctxStdoutKey, true)
 }
 
 func Logger() *slog.Logger {

--- a/pkg/manifest/k8s.go
+++ b/pkg/manifest/k8s.go
@@ -142,7 +142,7 @@ func initValidator(tempDir string) validator.Validator {
 	}
 
 	if extraSchemaSpecified && len(extraSchemaLoc) > 0 {
-		log.Info("User have specified an extra schema location", "location", extraSchemaLoc)
+		log.Debug("User have specified an extra schema location", "location", extraSchemaLoc)
 		schemaLocations = append(schemaLocations, extraSchemaLoc)
 	}
 


### PR DESCRIPTION
## Validate output fra stderr til stdout 🐛

Vi fikk inn ei melding fra en utvikler om at det ikke var mulig å pipe resultatet fra validate inn i grep. Dette var fordi validate logget resultatet og dermed ble resultatet skrevet til stderr og ikke stdout. Per UNIX-konvensjon så bør logging og resultater fra programmer separeres og foreslår at outputen fra validate bør gå til stdout, mens logging går til stderr.  

Nå kan du kjøre: 
```bash
./skipctl manifests validate -p=testdata/jsonnet/advanced/ | grep valid
validation completed: totalResources=1, **valid**=1, in**valid**=0, errors=0, skipped=0
```
Uten å møtte kjøre 
```bash 
./skipctl manifests validate -p=testdata/jsonnet/advanced/ 2>&1 | grep valid
```
for å få samme resultat 