### PR TITLE
🐛 Oppdatert diff for nye filer

### DIFF
--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -61,9 +61,17 @@ func lcs(a, b []string) [][]int {
 	return dp
 }
 
+func splitLines(s string) []string {
+	if s == "" {
+		return []string{}
+	}
+	return strings.Split(s, "\n")
+}
+
 func LCS(a, b string) ([]*ManifestDiff, bool) {
-	linesA := strings.Split(a, "\n")
-	linesB := strings.Split(b, "\n")
+	linesA := splitLines(a)
+	linesB := splitLines(b)
+
 	dp := lcs(linesA, linesB)
 	i, j := 0, 0
 	diffs := []*ManifestDiff{}

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -47,7 +47,9 @@ func GetFileContentAtRef(filename string, ref string) (*string, error) {
 
 	content, err := readPathFromTree(repo, tree, rel)
 	if err != nil {
-		return nil, fmt.Errorf("file %q not found in commit %s: %w", rel, ref, err)
+		content = ""
+		//nolint:nilerr // Intentionally treat any read error as "no content at commit"
+		return &content, nil // file does not exist at commit, return empty content
 	}
 	return &content, nil
 }

--- a/pkg/manifest/differ.go
+++ b/pkg/manifest/differ.go
@@ -50,15 +50,18 @@ func (d *Differ) DiffManifest(file *Document) error {
 		return err
 	}
 	rendered := d.renderBuffer.String()
+	prevRendered := ""
 
-	d.renderBuffer.Reset()
-	d.renderer.SetGitImporter(d.ref)
-	d.renderer.DisableYamlSeparator()
-	err = d.renderer.RenderManifest(prevFile)
-	if err != nil {
-		return err
+	if prevFile.Content != "" {
+		d.renderBuffer.Reset()
+		d.renderer.SetGitImporter(d.ref)
+		d.renderer.DisableYamlSeparator()
+		err = d.renderer.RenderManifest(prevFile)
+		if err != nil {
+			return err
+		}
+		prevRendered = d.renderBuffer.String()
 	}
-	prevRendered := d.renderBuffer.String()
 
 	diffs, hasChanges := diff.LCS(prevRendered, rendered)
 	if !hasChanges {

--- a/pkg/manifest/differ_test.go
+++ b/pkg/manifest/differ_test.go
@@ -178,3 +178,29 @@ spec:
 	require.Equal(t, expectedCountInsDel, deletionCount)
 	require.Equal(t, expectedCountEq, equalCount)
 }
+
+func TestDiffManifestYamlNewManifest(t *testing.T) {
+	yamlManifest1 := ``
+	yamlManifest2 := `apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: valid-manifest
+  namespace: production
+spec:
+  image: kartverket/example1
+  port: 8080
+  replicas:
+    min: 1
+    max: 15`
+
+	// Mock diffs with two different manifests
+	diffs, hasChanges := diff.LCS(yamlManifest1, yamlManifest2)
+	require.True(t, hasChanges, "expected changes but none were registered")
+	// Count diff types, this should be 3 insertions and deletions from these manifests
+	insertionCount, deletionCount, equalCount := countDiffTypes(diffs)
+	expectedCountIns, expectedCountDel, expectedCountEq := 11, 0, 0
+
+	require.Equal(t, expectedCountIns, insertionCount)
+	require.Equal(t, expectedCountDel, deletionCount)
+	require.Equal(t, expectedCountEq, equalCount)
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description 📝
During the workshop a user noted some unexpected behavior.
If you diff a file `foo.jsonnet` at commit `x`, but the file did not exist at that commit, `skipctl` will give an error.
The expected behavior is that all the lines in the new file are insertions, to show that the file is deleted.
Now, instead of returning an error when diffing against the non-existing file, it will give a diff.



## How Has This Been Tested? 🧪
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Created test for this new case.
- Test yourself by creating a new file and run `skipctl manifests diff` on that file

## Screenshots (if appropriate): 📸
<img width="648" height="236" alt="image" src="https://github.com/user-attachments/assets/f94e0190-4b86-4fb1-92a2-c4b63c681ad6" />

## Types of changes 🔄
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) 🐛

## Checklist: ✅
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. 💅
- [x] My changes do not break the existing tests 🧪
- [x] I have updated the tests accordingly ➕ 
- [ ] My change requires a change to the documentation. 📚
- [ ] I have updated the documentation accordingly. 📝

