### PR TITLE
✨ add aliases

### DIFF
--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -18,8 +18,9 @@ var (
 )
 
 var diffCmd = &cobra.Command{
-	Use:   "diff",
-	Short: "Diff manifest",
+	Use:     "diff",
+	Aliases: []string{"d"},
+	Short:   "Diff manifest",
 	Long: fmt.Sprintf(`Recursively diff manifest files in the specified path.
 
 

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -11,8 +11,9 @@ import (
 )
 
 var formatCmd = &cobra.Command{
-	Use:   "format",
-	Short: "Format manifest in place",
+	Use:     "format",
+	Aliases: []string{"f", "fmt"},
+	Short:   "Format manifest in place",
 	Long: fmt.Sprintf(`Recursively formats manifest files in the specified path.
 
 Supported formats are: %s.

--- a/cmd/manifest.go
+++ b/cmd/manifest.go
@@ -9,9 +9,10 @@ var (
 )
 
 var manifestCmd = &cobra.Command{
-	Use:   "manifests",
-	Short: "Work with manifests",
-	Long:  `Commands for working with manifests.`,
+	Use:     "manifests",
+	Aliases: []string{"m", "manifest"},
+	Short:   "Work with manifests",
+	Long:    `Commands for working with manifests.`,
 }
 
 func isStdin(args []string) bool {

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -15,8 +15,9 @@ var (
 )
 
 var renderCmd = &cobra.Command{
-	Use:   "render",
-	Short: "Render manifest files to stdout",
+	Use:     "render",
+	Aliases: []string{"r"},
+	Short:   "Render manifest files to stdout",
 	Long: fmt.Sprintf(`Recursively validates manifest files in the specified path.
 
 Supported formats are: %s.

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -16,11 +16,12 @@ import (
 var (
 	tempDir     string
 	validateCmd = &cobra.Command{
-		Use:   "validate",
-		Short: "Validate manifest files against well-known Kubernetes schemas",
-		Long:  fmt.Sprintf("Recursively validates %s files in the specified path", strings.Join(constants.ManifestSuffixes, ", ")),
-		RunE:  runValidate,
-		Args:  cobra.RangeArgs(0, 1),
+		Use:     "validate",
+		Aliases: []string{"v"},
+		Short:   "Validate manifest files against well-known Kubernetes schemas",
+		Long:    fmt.Sprintf("Recursively validates %s files in the specified path", strings.Join(constants.ManifestSuffixes, ", ")),
+		RunE:    runValidate,
+		Args:    cobra.RangeArgs(0, 1),
 		// SilenceErrors and SilenceUsage are set to true to prevent Cobra from printing errors and usage messages automatically.
 		// This allows for custom error handling and logging within the command's execution logic.
 		SilenceErrors: true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description 📝
Add short aliases to the `manifests` commands


**Aliases**
`manifests` -> `manifest` or `m`
`render` -> `r`
`validate` -> `v`
`diff` -> `d`
`format` -> `f` or `fmt`


## Motivation and Context 💡
Requested since the commands can become quite verbose

## How Has This Been Tested? 🧪
Tested manually in the terminal

## Types of changes 🔄
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality) ✨

## Checklist: ✅
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. 💅
- [x] My changes do not break the existing tests 🧪
- [ ] I have updated the tests accordingly ➕ 
- [ ] My change requires a change to the documentation. 📚
- [ ] I have updated the documentation accordingly. 📝
