### PR TITLE
Remove sec.champ from catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -10,15 +10,3 @@ spec:
   lifecycle: "production"
   owner: "skip"
   system: "skip"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Resource"
-metadata:
-  name: "skipctl"
-  links:
-  - url: "https://github.com/kartverket/skipctl"
-    title: "skipctl på GitHub"
-spec:
-  type: "repo"
-  dependencyOf:
-  - "component:skipctl"


### PR DESCRIPTION
Removed Group definition for security champion and updated Resource metadata.

## Motivation and Context 💡
New udpate in backstage removes the need for including sec champ in catalog.info