### PR TITLE
🐛 fix format bug with yaml separator

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -35,6 +35,7 @@ const (
 )
 const (
 	DefaultChunkSize = 3
+	YamlIndent       = 2
 )
 
 const (

--- a/pkg/manifest/formatter.go
+++ b/pkg/manifest/formatter.go
@@ -1,7 +1,11 @@
 package manifest
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
+	"io"
+	"strings"
 
 	"github.com/google/go-jsonnet/formatter"
 	"github.com/kartverket/skipctl/pkg/constants"
@@ -22,20 +26,33 @@ func formatJsonnet(file *Document) error {
 }
 
 func formatYaml(d *Document) error {
-	var out any
-	if err := yaml.Unmarshal([]byte(d.Content), &out); err != nil {
-		return err
+	decoder := yaml.NewDecoder(strings.NewReader(d.Content))
+	var output bytes.Buffer
+	encoder := yaml.NewEncoder(&output)
+	encoder.SetIndent(constants.YamlIndent)
+
+	for {
+		var node yaml.Node
+		decErr := decoder.Decode(&node)
+		if decErr != nil {
+			if errors.Is(decErr, io.EOF) {
+				break
+			}
+			return fmt.Errorf("failed to decode YAML: %w", decErr)
+		}
+
+		if len(node.Content) == 0 {
+			continue
+		}
+
+		if encErr := encoder.Encode(&node); encErr != nil {
+			return fmt.Errorf("failed to encode YAML: %w", encErr)
+		}
 	}
 
-	formattedYaml, merr := yaml.Marshal(out)
-	if merr != nil {
-		return merr
-	}
-
-	if werr := d.Write(string(formattedYaml)); werr != nil {
+	if werr := d.Write(output.String()); werr != nil {
 		return werr
 	}
-
 	return nil
 }
 func FormatManifest(file *Document) error {

--- a/testdata/multiformat/multi.yaml
+++ b/testdata/multiformat/multi.yaml
@@ -1,0 +1,24 @@
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: valid-manifest-patch-1
+  namespace: devex
+
+---
+
+apiVersion: skiperator.kartverket.no/v1alpha1
+kind: Application
+metadata:
+  name: valid-manifest-patch-2
+  namespace: devex
+
+---
+
+baz:
+          - 1
+          - 2
+          - 3
+foo: bar
+settings:
+          enabled: true
+          retries: 5


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description 📝
<!--- Describe your changes in detail -->
The yaml formatter is now change to support multi yaml files divided by "---".

## Motivation and Context 💡
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
An issue was presented where the formatter deleted configs in multi yaml separate by the "---".

## How Has This Been Tested? 🧪
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Multi yaml files were added to the repo to see if it formatted correctly. 
- Format was run over folders containing more files than yaml 
- Format was run with single yaml file to see that it does not break existing functionality 
  
## Types of changes 🔄
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) 🐛

## Checklist: ✅
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. 💅
- [x] My changes do not break the existing tests 🧪
