### PR TITLE
Offer option to mute telemetry enablement messages

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -96,9 +96,16 @@ func initTelemetry() {
 		}
 	}
 
+	muteTelemetry := false
+	if val, ok := os.LookupEnv("SKIPCTL_MUTE_TELEMETRY"); ok {
+		parsed, _ := strconv.ParseBool(val)
+		muteTelemetry = parsed
+	}
+
 	collector = telemetry.ConfigureCollector(telemetry.Options{
 		Debug:            debug,
 		DisableAnalytics: disableAnalytics,
+		MuteTelemetry:    muteTelemetry,
 		GitVersion:       GitTag,
 		GitCommitHash:    GitCommitHash,
 	})

--- a/pkg/telemetry/posthog.go
+++ b/pkg/telemetry/posthog.go
@@ -33,6 +33,7 @@ func (c *Collector) Enabled() bool {
 type Options struct {
 	Debug            bool
 	DisableAnalytics bool
+	MuteTelemetry    bool
 	GitVersion       string
 	GitCommitHash    string
 	Arch             string
@@ -45,17 +46,23 @@ func ConfigureCollector(opts Options) Collector {
 	collector := Collector{log: logger}
 	if len(PostHogProjectAPIToken) == 0 {
 		collector.enabled = false
-		logger.Info("telemetry is disabled because no PostHog project API token set – normal for development builds")
+		if !opts.MuteTelemetry {
+			logger.Info("telemetry is disabled because no PostHog project API token set – normal for development builds")
+		}
 		return collector
 	}
 
 	if opts.DisableAnalytics || len(PostHogProjectAPIToken) == 0 {
 		collector.enabled = false
-		logger.Info("telemetry is disabled")
+		if !opts.MuteTelemetry {
+			logger.Info("telemetry is disabled")
+		}
 		return collector
 	}
 
-	logger.Info("telemetry enabled, set DO_NOT_TRACK=true to disable")
+	if !opts.MuteTelemetry {
+		logger.Info("telemetry enabled, set DO_NOT_TRACK=true to disable or SKIPCTL_MUTE_TELEMETRY=true to mute this message")
+	}
 
 	config := posthog.Config{
 		Endpoint:               postHogURL,
@@ -200,6 +207,7 @@ func defaultProps(opts Options) posthog.Properties {
 	props := make(posthog.Properties)
 
 	props.Set("debug_mode", opts.Debug)
+	props.Set("telemetry_muted", opts.MuteTelemetry)
 	props.Set("app_version", opts.GitVersion)
 	props.Set("app_git_commit", opts.GitCommitHash)
 	props.Set("user_os", runtime.GOOS)

--- a/readme.md
+++ b/readme.md
@@ -178,3 +178,5 @@ You can disable analytics collection in two ways:
 
 1. Set the `DO_NOT_TRACK` environment variable to `true`
 2. Use the `--no-analytics` flag when running any `skipctl` command
+
+You can suppress analytics enablement messages (whether it enabled or not) by setting the environement variable `SKIPCTL_MUTE_TELEMETRY` to `true`. 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description 📝
Set SKIPCTL_MUTE_TELEMETRY to suppress information about whether telemetry is enabled or not.

## Motivation and Context 💡
I was tired of seeing the following messages:
```
- telemetry is disabled because no PostHog project API token set – normal for development builds
- telemetry is disabled
- telemetry enabled, set DO_NOT_TRACK=true to disable
```

## How Has This Been Tested? 🧪
Manually

## Screenshots (if appropriate): 📸

## Types of changes 🔄
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) 🐛
- [X] New feature (non-breaking change which adds functionality) ✨
- [ ] Breaking change (fix or feature that would cause existing functionality to change) 💥

## Checklist: ✅
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project. 💅
- [X] My changes do not break the existing tests 🧪
- [ ] I have updated the tests accordingly ➕ 
- [X] My change requires a change to the documentation. 📚
- [X] I have updated the documentation accordingly. 📝

## Also fixed: 🤩
<!---If this pull request also fixes something else that is not related to the main description. -->
<!---For example: you found a bug and it was a quick fix. It might be other stuff as well :) -->

## Questions: ❓
<!--- If you have some questions, put them under here pointwise. -->
