### PR TITLE
Remove okpedersen from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-* @kartverket/skip @okpedersen
+* @kartverket/skip
 /.security/ @omaen


### PR DESCRIPTION
Access to approve PRs was required temporarily, but is no longer needed.
